### PR TITLE
Frontend identity and bkt

### DIFF
--- a/_static/IdentityQuestions.js
+++ b/_static/IdentityQuestions.js
@@ -16,156 +16,6 @@ const MathQuestionModule = (function() {
     ];
 
     /**
-     * Inject required CSS styles for the math question module
-     */
-    function injectStyles() {
-        // Check if styles are already injected
-        if (document.getElementById('math-question-module-styles')) {
-            return;
-        }
-        
-        const style = document.createElement('style');
-        style.id = 'math-question-module-styles';
-        style.textContent = `
-            .math-question-module {
-                font-family: Arial, sans-serif;
-                margin: 20px 0;
-                padding: 15px;
-                border: 1px solid #ddd;
-                border-radius: 8px;
-                background-color: #f9f9f9;
-            }
-            
-            .question-categories {
-                display: flex;
-                gap: 10px;
-                margin: 15px 0;
-                flex-wrap: wrap;
-            }
-            
-            .category-box {
-                padding: 10px 15px;
-                border-radius: 5px;
-                cursor: pointer;
-                transition: all 0.3s;
-                border: 2px solid transparent;
-                font-weight: 500;
-            }
-            
-            .category-box:hover, .category-box.active {
-                transform: translateY(-2px);
-                box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-                border-color: #2196f3;
-            }
-            
-            .scientific { 
-                background-color: #e3f2fd; 
-                color: #1565c0;
-            }
-            .engineering { 
-                background-color: #e8f5e8; 
-                color: #2e7d32;
-            }
-            .financial { 
-                background-color: #fff3e0; 
-                color: #ef6c00;
-            }
-            .creative { 
-                background-color: #f3e5f5; 
-                color: #7b1fa2;
-            }
-            
-            .question-content {
-                display: none;
-                margin: 20px 0;
-                padding: 15px;
-                background-color: white;
-                border-radius: 5px;
-                border-left: 4px solid #2196f3;
-                box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            }
-            
-            .question-title {
-                font-weight: bold;
-                font-size: 1.1em;
-                margin-bottom: 10px;
-                color: #333;
-            }
-            
-            .answer-button {
-                background-color: #2196f3;
-                color: white;
-                padding: 8px 16px;
-                border-radius: 4px;
-                cursor: pointer;
-                display: inline-block;
-                margin: 10px 0;
-                transition: background-color 0.3s;
-                border: none;
-                font-size: 14px;
-            }
-            
-            .answer-button:hover {
-                background-color: #1976d2;
-            }
-            
-            .answer-content {
-                display: none;
-                margin-top: 10px;
-                padding: 15px;
-                background-color: #f5f5f5;
-                border-radius: 4px;
-                border-left: 3px solid #4caf50;
-            }
-            
-            .topic-intro {
-                margin: 15px 0;
-                color: #666;
-                line-height: 1.5;
-            }
-            
-            .math-question-module h2 {
-                color: #2c3e50;
-                margin-bottom: 15px;
-                font-size: 1.4em;
-            }
-            
-            /* Dark mode support */
-            @media (prefers-color-scheme: dark) {
-                .math-question-module {
-                    background-color: #2d3748;
-                    border-color: #4a5568;
-                    color: #e2e8f0;
-                }
-                
-                .question-content {
-                    background-color: #1a202c;
-                    color: #e2e8f0;
-                }
-                
-                .answer-content {
-                    background-color: #2d3748;
-                    color: #e2e8f0;
-                }
-                
-                .topic-intro {
-                    color: #a0aec0;
-                }
-                
-                .math-question-module h2 {
-                    color: #e2e8f0;
-                }
-                
-                .question-title {
-                    color: #e2e8f0;
-                }
-            }
-        `;
-        
-        document.head.appendChild(style);
-    }
-
-    /**
      * Handles LaTeX rendering for elements
      * @param {HTMLElement|HTMLElement[]} elements - Element(s) to process for LaTeX rendering
      */
@@ -207,9 +57,6 @@ const MathQuestionModule = (function() {
         
         // Merge provided options with defaults
         const moduleOptions = { ...defaultOptions, ...options };
-        
-        // Ensure styles are injected
-        injectStyles();
         
         // Find target element
         const targetElement = document.getElementById(targetElementId);
@@ -392,7 +239,6 @@ const MathQuestionModule = (function() {
     return {
         render,
         renderLatex,
-        injectStyles,
         DEFAULT_CATEGORIES
     };
-})();
+})();y

--- a/_static/IdentityQuestions.js
+++ b/_static/IdentityQuestions.js
@@ -241,4 +241,4 @@ const MathQuestionModule = (function() {
         renderLatex,
         DEFAULT_CATEGORIES
     };
-})();y
+})();

--- a/_static/style.css
+++ b/_static/style.css
@@ -164,10 +164,10 @@ html[data-theme="dark"] {
   --shadow-medium: 0 2px 10px rgba(0,0,0,0.3);
   --shadow-heavy: 0 4px 20px rgba(0,0,0,0.4);
 
-  --category-scientific: #60a5fa;
-  --category-engineering: #f97316;
-  --category-financial: #10b981;
-  --category-creative: #8b5cf6;
+  --category-scientific: #93c5fd;
+  --category-engineering: #fdba74;
+  --category-financial: #6ee7b7;
+  --category-creative: #c4b5fd;
 
   /* Visualization colors */
   --viz-bg-light: #ffffff;
@@ -329,7 +329,7 @@ h1, h2 {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-md);
-  margin-bottom: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl); /* Increased spacing after categories */
 }
 
 .math-question-module .category-box {
@@ -370,24 +370,66 @@ h1, h2 {
   color: var(--text-inverse);
 }
 
+/* Question content container - main styling */
 .math-question-module .question-content {
   background-color: var(--background-secondary);
   color: var(--text-primary);
+  padding: var(--spacing-lg); /* Added proper padding */
+  border-radius: var(--border-radius-md); /* Consistent border radius */
+  box-shadow: var(--shadow-light); /* Added shadow for depth */
+  margin-bottom: var(--spacing-lg); /* Space between questions */
+  border-left: 4px solid var(--primary); /* Left border like in screenshot */
 }
 
 .math-question-module .question-title {
   color: var(--text-primary);
+  font-weight: bold;
+  font-size: 1.1em;
+  margin-bottom: var(--spacing-md); /* Space after title */
 }
 
+/* Content area inside question */
+.math-question-module .question-content > div:not(.question-title):not(.answer-button):not(.answer-content) {
+  margin-bottom: var(--spacing-lg); /* Space after question content */
+  line-height: 1.6;
+}
+
+/* Answer button styling */
+.math-question-module .answer-button {
+  background-color: var(--primary);
+  color: var(--text-inverse);
+  border: none;
+  padding: var(--spacing-sm) var(--spacing-lg); /* Better button padding */
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  font-size: 14px;
+  margin: var(--spacing-md) 0; /* Margin above and below button */
+  display: inline-block;
+}
+
+.math-question-module .answer-button:hover {
+  background-color: var(--primary-hover);
+}
+
+/* Answer content styling */
 .math-question-module .answer-content {
   background-color: var(--background-primary);
   color: var(--text-primary);
   border-left: 4px solid var(--primary);
+  padding: var(--spacing-lg); /* Proper padding for answer area */
+  border-radius: var(--border-radius-sm);
+  margin-top: var(--spacing-md); /* Space above answer */
+  box-shadow: var(--shadow-light);
+  line-height: 1.6;
 }
 
 .math-question-module pre {
   background-color: var(--background-secondary);
   color: var(--text-primary);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-sm);
+  margin: var(--spacing-sm) 0;
 }
 
 /* Answer content colors by category */
@@ -405,6 +447,33 @@ h1, h2 {
 
 .math-question-module .creative-answer {
   border-left-color: var(--category-creative);
+}
+
+/* Active state for category boxes */
+.math-question-module .category-box.active {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-medium);
+  border: 2px solid var(--text-inverse);
+}
+
+/* Ensure proper spacing for mathematical expressions */
+.math-question-module .MathJax {
+  margin: var(--spacing-xs) 0;
+}
+
+/* Responsive adjustments for Math Question Module */
+@media (max-width: 768px) {
+  .math-question-module .question-content {
+    padding: var(--spacing-md);
+  }
+  
+  .math-question-module .answer-content {
+    padding: var(--spacing-md);
+  }
+  
+  .math-question-module .category-box {
+    min-width: 150px;
+  }
 }
 
 /*--------------------------------------------------------------------*\
@@ -645,27 +714,6 @@ h1, h2 {
   color: var(--success);
 }
 
-/* === SSQ (SELF-STUDY QUESTIONS) === */
-
-.question-title {
-  color: var(--text-primary);
-  font-weight: bold;
-  margin-bottom: var(--spacing-sm);
-}
-
-.answer-button {
-  background-color: var(--primary);
-  color: var(--text-inverse);
-  border: none;
-  padding: 8px 16px;
-  border-radius: var(--border-radius-sm);
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.answer-button:hover {
-  background-color: var(--primary-hover);
-}
 
 /* === NAVIGATION BUTTONS === */
 

--- a/_static/style.css
+++ b/_static/style.css
@@ -753,6 +753,545 @@ h1, h2 {
   cursor: not-allowed;
 }
 
+/* === BKT DEMO STYLES === */
+
+/* Main demo container */
+.bkt-demo-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--spacing-lg);
+  background: var(--background-primary);
+  min-height: 100vh;
+  font-family: inherit;
+  color: var(--text-primary);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+/* Main layout container */
+.bkt-demo-container .main-layout {
+  display: flex;
+  gap: var(--spacing-lg);
+  align-items: flex-start;
+}
+
+/* BKT section (left side) */
+.bkt-demo-container .bkt-section {
+  flex: 1;
+  min-width: 0;
+  max-width: 600px;
+}
+
+/* Graph section (right side) */
+.bkt-demo-container .graph-section {
+  flex: 1;
+  min-width: 0;
+  max-width: 700px;
+}
+
+/* Content containers */
+.bkt-demo-container .container {
+  background: var(--background-secondary);
+  padding: var(--spacing-xl);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-heavy);
+  margin-bottom: var(--spacing-lg);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border-light);
+  transition: all 0.3s ease;
+}
+
+/* Headings */
+.bkt-demo-container h1 {
+  color: var(--text-primary);
+  text-align: center;
+  margin-bottom: var(--spacing-sm);
+  font-size: 2.2em;
+  font-weight: 300;
+}
+
+.bkt-demo-container .subtitle {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1.1em;
+  margin-bottom: var(--spacing-xl);
+  font-style: italic;
+}
+
+/* Enhanced button styling */
+.bkt-demo-container button {
+  padding: var(--spacing-md) var(--spacing-lg) !important;
+  font-size: 16px !important;
+  border: none !important;
+  border-radius: 25px !important;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-family: inherit !important;
+  font-weight: 500 !important;
+  text-decoration: none !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+  vertical-align: middle;
+  line-height: 1.4;
+  box-shadow: var(--shadow-medium);
+}
+
+.bkt-demo-container .primary-btn {
+  background: linear-gradient(45deg, var(--primary), var(--primary-hover)) !important;
+  color: var(--text-inverse) !important;
+}
+
+.bkt-demo-container .primary-btn:hover {
+  background: linear-gradient(45deg, var(--primary-hover), var(--primary)) !important;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-heavy);
+}
+
+.bkt-demo-container .success-btn {
+  background: linear-gradient(45deg, var(--success), #2ecc71) !important;
+  color: var(--text-inverse) !important;
+}
+
+.bkt-demo-container .success-btn:hover {
+  background: linear-gradient(45deg, #1e8449, var(--success)) !important;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-heavy);
+}
+
+.bkt-demo-container .danger-btn {
+  background: linear-gradient(45deg, var(--error), #c0392b) !important;
+  color: var(--text-inverse) !important;
+}
+
+.bkt-demo-container .danger-btn:hover {
+  background: linear-gradient(45deg, #c0392b, #a93226) !important;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-heavy);
+}
+
+/* Enhanced status styling */
+.bkt-demo-container .status {
+  padding: var(--spacing-md) var(--spacing-lg) !important;
+  border-radius: var(--border-radius-md) !important;
+  margin: var(--spacing-md) 0 !important;
+  font-family: inherit !important;
+  font-size: 16px !important;
+  font-weight: 500;
+  text-align: center;
+  box-shadow: var(--shadow-light);
+}
+
+.bkt-demo-container .status.success {
+  background: var(--success-bg) !important;
+  color: var(--success) !important;
+  border: 1px solid var(--success) !important;
+}
+
+.bkt-demo-container .status.error {
+  background: var(--error-bg) !important;
+  color: var(--error) !important;
+  border: 1px solid var(--error) !important;
+}
+
+.bkt-demo-container .status.info {
+  background: var(--info-bg) !important;
+  color: var(--info) !important;
+  border: 1px solid var(--info) !important;
+}
+
+.bkt-demo-container .status.loading {
+  background: var(--warning-bg) !important;
+  color: var(--warning) !important;
+  border: 1px solid var(--warning) !important;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* Enhanced MCQ container styling */
+.bkt-demo-container .mcq-container {
+  background: var(--background-primary) !important;
+  border: 3px solid var(--primary) !important;
+  border-radius: var(--border-radius-lg) !important;
+  padding: var(--spacing-lg) !important;
+  margin: var(--spacing-lg) 0 !important;
+  box-shadow: var(--shadow-heavy);
+  backdrop-filter: blur(10px);
+  transition: all 0.3s ease;
+}
+
+.bkt-demo-container .mcq-question {
+  font-size: 20px !important;
+  font-weight: 600 !important;
+  margin-bottom: var(--spacing-lg) !important;
+  color: var(--text-primary) !important;
+  line-height: 1.4;
+}
+
+.bkt-demo-container .mcq-meta {
+  display: flex;
+  gap: var(--spacing-lg);
+  margin: var(--spacing-md) 0;
+  flex-wrap: wrap;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.bkt-demo-container .mcq-options {
+  margin: var(--spacing-lg) 0 !important;
+}
+
+.bkt-demo-container .mcq-option {
+  display: block !important;
+  margin: var(--spacing-sm) 0 !important;
+  padding: var(--spacing-md) var(--spacing-lg) !important;
+  background: var(--background-secondary) !important;
+  border: 2px solid var(--border-primary) !important;
+  border-radius: var(--border-radius-md) !important;
+  cursor: pointer !important;
+  transition: all 0.3s ease !important;
+  font-family: inherit !important;
+  font-size: 16px !important;
+  backdrop-filter: blur(5px);
+  color: var(--text-primary) !important;
+}
+
+.bkt-demo-container .mcq-option:hover {
+  background: var(--background-tertiary) !important;
+  border-color: var(--primary) !important;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-medium);
+}
+
+.bkt-demo-container .mcq-option.selected {
+  background: linear-gradient(45deg, var(--primary), var(--primary-hover)) !important;
+  color: var(--text-inverse) !important;
+  border-color: var(--primary-hover) !important;
+  box-shadow: var(--shadow-medium);
+}
+
+.bkt-demo-container .submit-btn {
+  background: linear-gradient(45deg, var(--success), #2ecc71) !important;
+  color: var(--text-inverse) !important;
+  padding: var(--spacing-md) var(--spacing-xl) !important;
+  font-size: 16px !important;
+  border: none !important;
+  border-radius: 25px !important;
+  cursor: pointer !important;
+  transition: all 0.3s ease !important;
+  margin-top: var(--spacing-lg) !important;
+  box-shadow: var(--shadow-medium);
+}
+
+.bkt-demo-container .submit-btn:hover:not(:disabled) {
+  background: linear-gradient(45deg, #1e8449, var(--success)) !important;
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-heavy);
+}
+
+.bkt-demo-container .submit-btn:disabled {
+  background: var(--border-secondary) !important;
+  cursor: not-allowed !important;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+/* Enhanced progress bar styling */
+.bkt-demo-container .progress-bar {
+  width: 100% !important;
+  height: 25px !important;
+  background-color: var(--background-tertiary) !important;
+  border-radius: var(--border-radius-lg) !important;
+  overflow: hidden !important;
+  margin: var(--spacing-md) 0 !important;
+  box-shadow: inset 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.bkt-demo-container .progress-fill {
+  height: 100% !important;
+  background: linear-gradient(45deg, var(--success), #2ecc71) !important;
+  transition: width 0.5s ease !important;
+  border-radius: var(--border-radius-lg);
+  box-shadow: 0 2px 10px rgba(39, 174, 96, 0.3);
+}
+
+/* Legend styling */
+.bkt-demo-container .mastery-legend {
+  background: var(--background-primary);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-md);
+  margin: var(--spacing-sm) 0;
+  border: 1px solid var(--border-light);
+  box-shadow: var(--shadow-medium);
+  backdrop-filter: blur(10px);
+  font-size: 13px;
+  transition: all 0.3s ease;
+}
+
+.bkt-demo-container .gradient-legend {
+  margin: var(--spacing-sm) 0 var(--spacing-md) 0;
+}
+
+.bkt-demo-container .gradient-bar {
+  height: 20px;
+  background: linear-gradient(to right, 
+    hsl(0, 80%, 50%) 0%,
+    hsl(30, 80%, 50%) 25%,
+    hsl(60, 80%, 50%) 50%,
+    hsl(90, 80%, 50%) 75%,
+    hsl(120, 80%, 50%) 100%
+  );
+  border-radius: var(--border-radius-md);
+  border: 2px solid var(--text-primary);
+  margin-bottom: var(--spacing-xs);
+}
+
+.bkt-demo-container .gradient-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.bkt-demo-container .legend-item {
+  display: block;
+  margin-bottom: var(--spacing-xs);
+  color: var(--text-primary);
+}
+
+.bkt-demo-container .legend-color {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  margin-right: var(--spacing-xs);
+  vertical-align: middle;
+  border: 2px solid var(--text-primary);
+  box-shadow: var(--shadow-light);
+}
+
+.bkt-demo-container .legend-color-not-studied {
+  background-color: var(--text-muted);
+}
+
+/* Loading spinners */
+.bkt-demo-container .loading-spinner {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 3px solid var(--background-tertiary);
+  border-top: 3px solid var(--primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-right: var(--spacing-sm);
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Graph loading spinner */
+.bkt-demo-container .graph-loading {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  right: 1px;
+  bottom: 1px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: var(--background-secondary);
+  border-radius: var(--border-radius-md);
+  z-index: 10;
+}
+
+.bkt-demo-container .graph-loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--background-tertiary);
+  border-top: 4px solid var(--primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: var(--spacing-md);
+}
+
+.bkt-demo-container .graph-loading-text {
+  color: var(--text-secondary);
+  font-size: 16px;
+  font-weight: 500;
+}
+
+/* Graph container styling */
+.bkt-demo-container #graph-container {
+  width: 100%;
+  height: 500px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--border-radius-md);
+}
+
+/* Vis.js network navigation buttons dark mode fix - try different selectors */
+.bkt-demo-container #graph-container .vis-navigation .vis-button,
+.bkt-demo-container #graph-container .vis-network-navigation .vis-button,
+.bkt-demo-container #graph-container div[style*="background"] button {
+  background: var(--background-primary) !important;
+  color: var(--text-primary) !important;
+  border: 1px solid var(--border-primary) !important;
+}
+
+/* MCQ result containers */
+.bkt-demo-container .mcq-result-success {
+  border-color: var(--success) !important;
+  background-color: var(--success-bg) !important;
+  color: var(--success) !important;
+}
+
+.bkt-demo-container .mcq-result-error {
+  border-color: var(--error) !important;
+  background-color: var(--error-bg) !important;
+  color: var(--error) !important;
+}
+
+.bkt-demo-container .mcq-result-inner {
+  background: var(--background-primary) !important;
+  padding: var(--spacing-lg);
+  margin: var(--spacing-md) 0;
+  border-radius: var(--border-radius-md);
+  color: var(--text-primary) !important;
+  box-shadow: var(--shadow-medium);
+}
+
+.bkt-demo-container #controls {
+  margin-top: var(--spacing-md);
+}
+
+.bkt-demo-container #controls label {
+  color: var(--text-primary);
+  margin-right: var(--spacing-sm);
+}
+
+.bkt-demo-container #controls select {
+  background: var(--background-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--border-radius-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.bkt-demo-container #controls button {
+  margin-left: var(--spacing-sm);
+  background: var(--primary);
+  color: var(--text-inverse);
+  border: none;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.bkt-demo-container #controls button:hover {
+  background: var(--primary-hover);
+}
+
+.bkt-demo-container #node-info {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm);
+  background-color: var(--background-secondary);
+  border-radius: var(--border-radius-md);
+  display: none;
+}
+
+.bkt-demo-container #node-info h4 {
+  color: var(--text-primary);
+  margin-top: 0;
+}
+
+.bkt-demo-container #stats {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm);
+  background-color: var(--background-tertiary);
+  border-radius: var(--border-radius-md);
+  color: var(--text-primary);
+}
+
+/* Responsive design */
+@media (max-width: 1024px) {
+  .bkt-demo-container .main-layout {
+    flex-direction: column;
+  }
+  
+  .bkt-demo-container .bkt-section,
+  .bkt-demo-container .graph-section {
+    max-width: none;
+  }
+  
+  .bkt-demo-container #graph-container {
+    height: 400px !important;
+  }
+  
+  .bkt-demo-container .graph-loading-spinner {
+    width: 30px !important;
+    height: 30px !important;
+    border-width: 3px !important;
+  }
+  
+  .bkt-demo-container .graph-loading-text {
+    font-size: 14px !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .bkt-demo-container {
+    padding: var(--spacing-sm);
+  }
+  
+  .bkt-demo-container h1 {
+    font-size: 1.8em;
+  }
+  
+  .bkt-demo-container .mcq-meta {
+    flex-direction: column;
+    gap: var(--spacing-sm);
+  }
+  
+  .bkt-demo-container .legend-item {
+    margin-bottom: var(--spacing-sm);
+  }
+  
+  .bkt-demo-container #graph-container {
+    height: 350px !important;
+  }
+  
+  .bkt-demo-container .graph-loading-spinner {
+    width: 25px !important;
+    height: 25px !important;
+    border-width: 2px !important;
+  }
+  
+  .bkt-demo-container .graph-loading-text {
+    font-size: 12px !important;
+  }
+  
+  .bkt-demo-container #controls {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+  }
+  
+  .bkt-demo-container #controls label,
+  .bkt-demo-container #controls select,
+  .bkt-demo-container #controls button {
+    width: 100%;
+    margin: 0;
+  }
+}
+
 /*--------------------------------------------------------------------*\
 6. SUPPORTING CONTENT
 \*--------------------------------------------------------------------*/

--- a/content/functions/quadratic_functions_gen.md
+++ b/content/functions/quadratic_functions_gen.md
@@ -241,7 +241,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 #### Sector Specific Questions: Linear Equations Applications
 
-<div id="linear-revision-identity-container"></div>
+<div class="math-question-module" id="linear-revision-identity-container"></div>
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/content/interactive/BKT_Simple_Demo.md
+++ b/content/interactive/BKT_Simple_Demo.md
@@ -29,585 +29,6 @@ html_theme.sidebar_secondary.remove: true
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     
-   <style>
-      /* Override Jupyter Book styles for BKT demo */
-      .bd-content .bkt-demo-container {
-        max-width: 1400px;
-        margin: 0 auto;
-        padding: 20px;
-        background: var(--pst-color-background, #f8f9fa);
-        min-height: 100vh;
-        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-        color: var(--pst-color-text-base, #2c3e50);
-        transition: background-color 0.3s ease, color 0.3s ease;
-      }
-      
-      /* Main layout container */
-      .main-layout {
-        display: flex;
-        gap: 20px;
-        align-items: flex-start;
-      }
-      
-      /* BKT section (left side) */
-      .bkt-section {
-        flex: 1;
-        min-width: 0;
-        max-width: 600px;
-      }
-      
-      /* Graph section (right side) */
-      .graph-section {
-        flex: 1;
-        min-width: 0;
-        max-width: 700px;
-      }
-      
-      .bkt-demo-container .container {
-        background: var(--pst-color-surface, rgba(255, 255, 255, 0.95));
-        padding: 30px;
-        border-radius: 15px;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.1);
-        margin-bottom: 20px;
-        backdrop-filter: blur(10px);
-        border: 1px solid var(--pst-color-border, rgba(255,255,255,0.2));
-        transition: all 0.3s ease;
-      }
-      
-      .bkt-demo-container h1 {
-        color: var(--pst-color-text-base, #2c3e50);
-        text-align: center;
-        margin-bottom: 10px;
-        font-size: 2.2em;
-        font-weight: 300;
-      }
-      
-      .bkt-demo-container .subtitle {
-        text-align: center;
-        color: var(--pst-color-text-muted, #7f8c8d);
-        font-size: 1.1em;
-        margin-bottom: 30px;
-        font-style: italic;
-      }
-      
-      /* Enhanced button styling */
-      .bkt-demo-container button {
-        padding: 15px 25px !important;
-        font-size: 16px !important;
-        border: none !important;
-        border-radius: 25px !important;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
-        font-weight: 500 !important;
-        text-decoration: none !important;
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        text-align: center;
-        vertical-align: middle;
-        line-height: 1.4;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-      }
-      
-      .bkt-demo-container .primary-btn {
-        background: linear-gradient(45deg, #3498db, #2980b9) !important;
-        color: white !important;
-      }
-      
-      .bkt-demo-container .primary-btn:hover {
-        background: linear-gradient(45deg, #2980b9, #1f5f8b) !important;
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.2);
-      }
-      
-      .bkt-demo-container .success-btn {
-        background: linear-gradient(45deg, #27ae60, #2ecc71) !important;
-        color: white !important;
-      }
-      
-      .bkt-demo-container .success-btn:hover {
-        background: linear-gradient(45deg, #1e8449, #27ae60) !important;
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.2);
-      }
-      
-      .bkt-demo-container .danger-btn {
-        background: linear-gradient(45deg, #e74c3c, #c0392b) !important;
-        color: white !important;
-      }
-      
-      .bkt-demo-container .danger-btn:hover {
-        background: linear-gradient(45deg, #c0392b, #a93226) !important;
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.2);
-      }
-      
-      /* Enhanced status styling */
-      .bkt-demo-container .status {
-        padding: 15px 20px !important;
-        border-radius: 10px !important;
-        margin: 15px 0 !important;
-        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
-        font-size: 16px !important;
-        font-weight: 500;
-        text-align: center;
-        box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-      }
-      
-      .bkt-demo-container .status.success {
-        background: linear-gradient(45deg, #d4edda, #c3e6cb) !important;
-        color: #155724 !important;
-        border: 1px solid #c3e6cb !important;
-      }
-      
-      .bkt-demo-container .status.error {
-        background: linear-gradient(45deg, #f8d7da, #f5c6cb) !important;
-        color: #721c24 !important;
-        border: 1px solid #f5c6cb !important;
-      }
-      
-      .bkt-demo-container .status.info {
-        background: linear-gradient(45deg, #d1ecf1, #bee5eb) !important;
-        color: #0c5460 !important;
-        border: 1px solid #bee5eb !important;
-      }
-      
-      .bkt-demo-container .status.loading {
-        background: linear-gradient(45deg, #fff3cd, #ffeaa7) !important;
-        color: #856404 !important;
-        border: 1px solid #ffeaa7 !important;
-        animation: pulse 1.5s infinite;
-      }
-      
-      @keyframes pulse {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.7; }
-      }
-      
-      /* Enhanced MCQ container styling */
-      .bkt-demo-container .mcq-container {
-        background: var(--pst-color-surface, rgba(255, 255, 255, 0.95)) !important;
-        border: 3px solid #3498db !important;
-        border-radius: 15px !important;
-        padding: 25px !important;
-        margin: 20px 0 !important;
-        box-shadow: 0 8px 25px rgba(0,0,0,0.1);
-        backdrop-filter: blur(10px);
-        transition: all 0.3s ease;
-      }
-      
-      .bkt-demo-container .mcq-question {
-        font-size: 20px !important;
-        font-weight: 600 !important;
-        margin-bottom: 20px !important;
-        color: var(--pst-color-text-base, #2c3e50) !important;
-        line-height: 1.4;
-      }
-      
-      .bkt-demo-container .mcq-meta {
-        display: flex;
-        gap: 20px;
-        margin: 15px 0;
-        flex-wrap: wrap;
-        color: var(--pst-color-text-muted, #7f8c8d);
-        font-size: 14px;
-      }
-      
-      .bkt-demo-container .mcq-options {
-        margin: 20px 0 !important;
-      }
-      
-      .bkt-demo-container .mcq-option {
-        display: block !important;
-        margin: 10px 0 !important;
-        padding: 15px 20px !important;
-        background: rgba(248, 249, 250, 0.8) !important;
-        border: 2px solid #e9ecef !important;
-        border-radius: 10px !important;
-        cursor: pointer !important;
-        transition: all 0.3s ease !important;
-        font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
-        font-size: 16px !important;
-        backdrop-filter: blur(5px);
-        color: var(--pst-color-text-base, #2c3e50) !important;
-      }
-      
-      .bkt-demo-container .mcq-option:hover {
-        background: rgba(233, 236, 239, 0.9) !important;
-        border-color: #3498db !important;
-        transform: translateY(-1px);
-        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-      }
-      
-      .bkt-demo-container .mcq-option.selected {
-        background: linear-gradient(45deg, #3498db, #2980b9) !important;
-        color: white !important;
-        border-color: #2980b9 !important;
-        box-shadow: 0 4px 15px rgba(52, 152, 219, 0.3);
-      }
-      
-      .bkt-demo-container .submit-btn {
-        background: linear-gradient(45deg, #27ae60, #2ecc71) !important;
-        color: white !important;
-        padding: 15px 30px !important;
-        font-size: 16px !important;
-        border: none !important;
-        border-radius: 25px !important;
-        cursor: pointer !important;
-        transition: all 0.3s ease !important;
-        margin-top: 20px !important;
-        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-      }
-      
-      .bkt-demo-container .submit-btn:hover:not(:disabled) {
-        background: linear-gradient(45deg, #1e8449, #27ae60) !important;
-        transform: translateY(-2px);
-        box-shadow: 0 6px 20px rgba(0,0,0,0.2);
-      }
-      
-      .bkt-demo-container .submit-btn:disabled {
-        background: #bdc3c7 !important;
-        cursor: not-allowed !important;
-        transform: none !important;
-        box-shadow: none !important;
-      }
-      
-      /* Enhanced progress bar styling */
-      .bkt-demo-container .progress-bar {
-        width: 100% !important;
-        height: 25px !important;
-        background-color: #ecf0f1 !important;
-        border-radius: 15px !important;
-        overflow: hidden !important;
-        margin: 15px 0 !important;
-        box-shadow: inset 0 2px 5px rgba(0,0,0,0.1);
-      }
-      
-      .bkt-demo-container .progress-fill {
-        height: 100% !important;
-        background: linear-gradient(45deg, #27ae60, #2ecc71) !important;
-        transition: width 0.5s ease !important;
-        border-radius: 15px;
-        box-shadow: 0 2px 10px rgba(39, 174, 96, 0.3);
-      }
-
-      /* Legend styling */
-      .mastery-legend {
-        background: var(--pst-color-surface, rgba(255, 255, 255, 0.95));
-        padding: 15px;
-        border-radius: 12px;
-        margin: 10px 0;
-        border: 1px solid var(--pst-color-border, rgba(255,255,255,0.2));
-        box-shadow: 0 4px 15px rgba(0,0,0,0.1);
-        backdrop-filter: blur(10px);
-        font-size: 13px;
-        transition: all 0.3s ease;
-      }
-      
-      .gradient-legend {
-        margin: 10px 0 15px 0;
-      }
-      
-      .gradient-bar {
-        height: 20px;
-        background: linear-gradient(to right, 
-          hsl(0, 80%, 50%) 0%,
-          hsl(30, 80%, 50%) 25%,
-          hsl(60, 80%, 50%) 50%,
-          hsl(90, 80%, 50%) 75%,
-          hsl(120, 80%, 50%) 100%
-        );
-        border-radius: 10px;
-        border: 2px solid var(--pst-color-text-base, #2c3e50);
-        margin-bottom: 5px;
-      }
-      
-      .gradient-labels {
-        display: flex;
-        justify-content: space-between;
-        font-size: 11px;
-        color: var(--pst-color-text-base, #2c3e50);
-        font-weight: 500;
-      }
-      
-      .legend-item {
-        display: block;
-        margin-bottom: 8px;
-        color: var(--pst-color-text-base, #2c3e50);
-      }
-      
-      .legend-color {
-        display: inline-block;
-        width: 16px;
-        height: 16px;
-        border-radius: 50%;
-        margin-right: 8px;
-        vertical-align: middle;
-        border: 2px solid var(--pst-color-text-base, #2c3e50);
-        box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-      }
-      
-      /* Loading spinner */
-      .loading-spinner {
-        display: inline-block;
-        width: 20px;
-        height: 20px;
-        border: 3px solid #f3f3f3;
-        border-top: 3px solid #3498db;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-        margin-right: 10px;
-      }
-      
-      @keyframes spin {
-        0% { transform: rotate(0deg); }
-        100% { transform: rotate(360deg); }
-      }
-      
-      /* Graph loading spinner */
-      .graph-loading {
-        position: absolute;
-        top: 1px;
-        left: 1px;
-        right: 1px;
-        bottom: 1px;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        background: var(--pst-color-surface, rgba(248, 249, 250, 0.95));
-        border-radius: 8px;
-        z-index: 10;
-      }
-      
-      .graph-loading-spinner {
-        width: 40px;
-        height: 40px;
-        border: 4px solid #e9ecef;
-        border-top: 4px solid #3498db;
-        border-radius: 50%;
-        animation: spin 1s linear infinite;
-        margin-bottom: 15px;
-      }
-      
-      .graph-loading-text {
-        color: var(--pst-color-text-muted, #6c757d);
-        font-size: 16px;
-        font-weight: 500;
-      }
-
-      /* ========== DARK MODE OVERRIDES ========== */
-      
-      /* Dark mode container background */
-      html[data-theme="dark"] .bkt-demo-container {
-        background: #1a1a1a !important;
-        color: #e9ecef !important;
-      }
-      
-      /* Dark mode container boxes */
-      html[data-theme="dark"] .bkt-demo-container .container {
-        background: var(--dark-gray-dark, #374151) !important;
-        border: 1px solid var(--dark-gray-medium, #4a5568) !important;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.3) !important;
-      }
-      
-      /* Dark mode headings */
-      html[data-theme="dark"] .bkt-demo-container h1,
-      html[data-theme="dark"] .bkt-demo-container .subtitle {
-        color: #f8f9fa !important;
-      }
-      
-      /* Dark mode MCQ container */
-      html[data-theme="dark"] .bkt-demo-container .mcq-container {
-        background: var(--dark-gray-darker) !important;
-        border-color: #3498db !important;
-        color: #e9ecef !important;
-      }
-      
-      /* Dark mode MCQ question */
-      html[data-theme="dark"] .bkt-demo-container .mcq-question {
-        color: #f8f9fa !important;
-      }
-      
-      /* Dark mode MCQ meta */
-      html[data-theme="dark"] .bkt-demo-container .mcq-meta {
-        color: #adb5bd !important;
-      }
-      
-      /* Dark mode MCQ options */
-      html[data-theme="dark"] .bkt-demo-container .mcq-option {
-        background: var(--dark-gray-dark, #374151) !important;
-        color: #e9ecef !important;
-        border-color: var(--dark-gray-medium, #4a5568) !important;
-      }
-      
-      html[data-theme="dark"] .bkt-demo-container .mcq-option:hover {
-        background: var(--dark-gray-medium, #4a5568) !important;
-        border-color: var(--dark-gray-light, #6b7280) !important;
-      }
-      
-      /* Dark mode status messages */
-      html[data-theme="dark"] .bkt-demo-container .status.success {
-        background: #065f46 !important;
-        color: #d1fae5 !important;
-        border-color: #10b981 !important;
-      }
-      
-      html[data-theme="dark"] .bkt-demo-container .status.error {
-        background: #7f1d1d !important;
-        color: #fecaca !important;
-        border-color: #ef4444 !important;
-      }
-      
-      html[data-theme="dark"] .bkt-demo-container .status.info {
-        background: #1e3a8a !important;
-        color: #dbeafe !important;
-        border-color: #3b82f6 !important;
-      }
-      
-      html[data-theme="dark"] .bkt-demo-container .status.loading {
-        background: #92400e !important;
-        color: #fef3c7 !important;
-        border-color: #f59e0b !important;
-      }
-      
-      /* Dark mode progress bar */
-      html[data-theme="dark"] .bkt-demo-container .progress-bar {
-        background-color: var(--dark-gray-dark, #374151) !important;
-      }
-      
-      /* Keep progress fill green in dark mode */
-      html[data-theme="dark"] .bkt-demo-container .progress-fill {
-        background: linear-gradient(45deg, #27ae60, #2ecc71) !important;
-        box-shadow: 0 2px 10px rgba(39, 174, 96, 0.3) !important;
-      }
-      
-      /* Dark mode legend */
-      html[data-theme="dark"] .mastery-legend {
-        background: var(--dark-gray-dark, #374151) !important;
-        border-color: var(--dark-gray-medium, #4a5568) !important;
-      }
-      
-      html[data-theme="dark"] .gradient-bar {
-        border-color: #f8f9fa !important;
-      }
-      
-      html[data-theme="dark"] .gradient-labels,
-      html[data-theme="dark"] .legend-item {
-        color: #f8f9fa !important;
-      }
-      
-      html[data-theme="dark"] .legend-color {
-        border-color: #f8f9fa !important;
-      }
-      
-      /* Dark mode loading states */
-      html[data-theme="dark"] .graph-loading {
-        background: rgba(55, 65, 81, 0.95) !important;
-      }
-      
-      /* Override inline styles for any BKT visualization elements */
-      html[data-theme="dark"] .bkt-demo-container [style*="background"]:not(.progress-bar):not(.progress-fill) {
-        background: var(--dark-gray-dark, #374151) !important;
-      }
-      
-      html[data-theme="dark"] .bkt-demo-container [style*="rgba(255, 255, 255"]:not(.progress-bar):not(.progress-fill) {
-        background: var(--dark-gray-dark, #374151) !important;
-      }
-      
-      html[data-theme="dark"] .bkt-demo-container [style*="background-color: white"]:not(.progress-bar):not(.progress-fill),
-      html[data-theme="dark"] .bkt-demo-container [style*="background-color:#ffffff"]:not(.progress-bar):not(.progress-fill),
-      html[data-theme="dark"] .bkt-demo-container [style*="background-color: #ffffff"]:not(.progress-bar):not(.progress-fill) {
-        background-color: var(--dark-gray-dark, #374151) !important;
-      }
-      
-      html[data-theme="dark"] .graph-loading-spinner {
-        border-color: #4a5568 !important;
-        border-top-color: #3498db !important;
-      }
-      
-      html[data-theme="dark"] .graph-loading-text {
-        color: #adb5bd !important;
-      }
-      
-      /* Dark mode disabled buttons */
-      html[data-theme="dark"] .bkt-demo-container .submit-btn:disabled {
-        background: #4a5568 !important;
-        color: #9ca3af !important;
-      }
-      
-      /* Responsive design */
-      @media (max-width: 1024px) {
-        .main-layout {
-          flex-direction: column;
-        }
-        
-        .bkt-section,
-        .graph-section {
-          max-width: none;
-        }
-        
-        #graph-container {
-          height: 400px !important;
-        }
-        
-        .graph-loading-spinner {
-          width: 30px !important;
-          height: 30px !important;
-          border-width: 3px !important;
-        }
-        
-        .graph-loading-text {
-          font-size: 14px !important;
-        }
-      }
-      
-      @media (max-width: 768px) {
-        .bkt-demo-container {
-          padding: 10px;
-        }
-        
-        .bkt-demo-container h1 {
-          font-size: 1.8em;
-        }
-        
-        .bkt-demo-container .mcq-meta {
-          flex-direction: column;
-          gap: 10px;
-        }
-        
-        .legend-item {
-          margin-bottom: 10px;
-        }
-        
-        #graph-container {
-          height: 350px !important;
-        }
-        
-        .graph-loading-spinner {
-          width: 25px !important;
-          height: 25px !important;
-          border-width: 2px !important;
-        }
-        
-        .graph-loading-text {
-          font-size: 12px !important;
-        }
-        
-        #controls {
-          display: flex;
-          flex-direction: column;
-          gap: 10px;
-        }
-        
-        #controls label,
-        #controls select,
-        #controls button {
-          width: 100%;
-        }
-      }
-</style>
 </head>
 <body>
     <div class="bkt-demo-container">
@@ -646,20 +67,19 @@ html_theme.sidebar_secondary.remove: true
                 </div>
               </div>
               <div class="legend-item">
-                <span class="legend-color" style="background-color: #6c757d;"></span>
+                <span class="legend-color legend-color-not-studied"></span>
                 <span>Not Yet Studied</span>
               </div>
             </div>
-            
             <div style="position: relative;">
-              <div id="graph-container" style="width: 100%; height: 500px; border: 1px solid #ddd; border-radius: 8px;"></div>
+              <div id="graph-container"></div>
               <div id="graph-loading" class="graph-loading">
                 <div class="graph-loading-spinner"></div>
                 <div class="graph-loading-text">Loading Knowledge Graph...</div>
               </div>
             </div>
 
-            <div id="controls" style="margin-top: 15px;">
+            <div id="controls">
               <label for="strand-filter">Filter by Strand: </label>
               <select id="strand-filter">
                 <option value="">All Strands</option>
@@ -673,20 +93,20 @@ html_theme.sidebar_secondary.remove: true
                 <option value="Coordinate Geometry">Coordinate Geometry</option>
               </select>
               
-              <button id="reset-view" style="margin-left: 10px;">Reset View</button>
-              <button id="toggle-physics" style="margin-left: 10px;">Toggle Physics</button>
-              <button id="load-simplified" style="margin-left: 10px;">Load Small Dense Graph</button>
-              <button id="load-full" style="margin-left: 10px;">Load Full</button>
+              <button id="reset-view">Reset View</button>
+              <button id="toggle-physics">Toggle Physics</button>
+              <button id="load-simplified">Load Small Dense Graph</button>
+              <button id="load-full">Load Full</button>
             </div>
 
-            <div id="node-info" style="margin-top: 15px; padding: 10px; background-color: #f8f9fa; border-radius: 8px; display: none;">
+            <div id="node-info" style="display: none;">
               <h4 id="node-title"></h4>
               <p id="node-description"></p>
               <p><strong>Strand:</strong> <span id="node-strand"></span></p>
               <p><strong>Mastery Level:</strong> <span id="node-mastery"></span></p>
             </div>
 
-            <div id="stats" style="margin-top: 15px; padding: 10px; background-color: #e9ecef; border-radius: 8px;">
+            <div id="stats">
               <strong>Graph Statistics:</strong> <span id="node-count">0</span> nodes, <span id="edge-count">0</span> edges
             </div>
           </div>
@@ -1112,20 +532,18 @@ html_theme.sidebar_secondary.remove: true
       function displayResult(result) {
         const mcqSection = document.getElementById('mcq-section');
         const isCorrect = result.is_correct;
-        const borderColor = isCorrect ? '#27ae60' : '#e74c3c';
-        const bgColor = isCorrect ? 'rgba(212, 237, 218, 0.9)' : 'rgba(248, 215, 218, 0.9)';
-        const textColor = isCorrect ? '#155724' : '#721c24';
+        const resultClass = isCorrect ? 'mcq-result-success' : 'mcq-result-error';
         const icon = isCorrect ? '✅' : '❌';
         const changeIcon = result.mastery_change > 0 ? '📈' : result.mastery_change < 0 ? '📉' : '➖';
         
         mcqSection.innerHTML = `
-          <div class="mcq-container" style="border-color: ${borderColor}; background-color: ${bgColor}; color: ${textColor};">
+          <div class="mcq-container ${resultClass}">
             <h3>${icon} ${isCorrect ? 'Excellent!' : 'Not quite right, but you\'re learning!'}</h3>
             <p><strong>Your Answer:</strong> ${result.selected_text}</p>
             <p><strong>Correct Answer:</strong> ${result.correct_option}</p>
             <p><strong>Explanation:</strong> ${result.explanation}</p>
             
-            <div style="background: rgba(255, 255, 255, 0.95); padding: 20px; margin: 15px 0; border-radius: 10px; color: #2c3e50; box-shadow: 0 4px 15px rgba(0,0,0,0.1);">
+            <div class="mcq-result-inner">
               <h4>🧠 BKT Mastery Update</h4>
               <p><strong>📚 Topic:</strong> ${result.main_topic}</p>
               <p><strong>📊 Before:</strong> ${(result.before_mastery * 100).toFixed(1)}%</p>
@@ -1134,12 +552,12 @@ html_theme.sidebar_secondary.remove: true
               <p><strong>🔄 Total Topics Updated:</strong> ${result.total_changes}</p>
               <p><em>💡 Check the knowledge graph below to see the color changes!</em></p>
               
-              <div class="progress-bar" style="margin: 15px 0;">
-                <div class="progress-fill" style="width: ${result.after_mastery * 100}%; background: ${result.after_mastery > result.before_mastery ? 'linear-gradient(45deg, #27ae60, #2ecc71)' : 'linear-gradient(45deg, #f39c12, #e67e22)'};"></div>
+              <div class="progress-bar">
+                <div class="progress-fill" style="width: ${result.after_mastery * 100}%;"></div>
               </div>
             </div>
             
-            <button onclick="nextQuestion()" class="submit-btn" style="background: linear-gradient(45deg, #3498db, #2980b9) !important;">
+            <button onclick="nextQuestion()" class="submit-btn">
               🚀 Next Question
             </button>
           </div>


### PR DESCRIPTION
Remove inline CSS from Identity Questions, fix theme integration
    - Delete injectStyles() function with hardcoded colors
    - Integrate with CSS variable system

Remove inline CSS from BKT demo and Identity Questions, integrate with themes system
    - Delete 750+ lines of inline CSS across components
    - Add BKT demo styles to main stylesheet with CSS variables
    - Replace hardcoded colors with theme-aware variables
    - Ensure automatic light/dark mode switching